### PR TITLE
Update maturity level

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - **Identifier:** <https://stac-extensions.github.io/timestamps/v1.0.0/schema.json>
 - **Field Name Prefix:** -
 - **Scope:** Item, Collection
-- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Proposal
+- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Pilot
 - **Owner**: @m-mohr
 - **History**: [Prior to March 2, 2021](https://github.com/radiantearth/stac-spec/commits/v1.0.0-rc.1/extensions/timestamps)
 


### PR DESCRIPTION
Update the maturity level to Pilot following the STAC maturity classification.

Reason: 2 implementations, but a couple of open issues